### PR TITLE
Remove need to specify username in the deployment script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,10 @@
 #!/bin/sh
 
-if [ "$1" = "" ]; then
-    echo "Usage: $0 username"
-    exit 1
+USER=$1
+if [ "$USER" = "" ]; then
+    USER=$LOGNAME
 fi
 
-USER=$1
 HOST=linux2.cs.ox.ac.uk
 DIR=/fs/website/projects/RSE/
 


### PR DESCRIPTION
Use my local username if I didn't give a different one on the command line.