### PR TITLE
Update date of upcoming training courses

### DIFF
--- a/content/events/2020-07-22_continuous_integration_course.md
+++ b/content/events/2020-07-22_continuous_integration_course.md
@@ -1,7 +1,7 @@
 ---
 title: "Continuous Integration Course"
 date: 2020-07-22T14:00:00+01:00
-draft: true
+draft: false
 publishDate: 2020-06-17
 ---
 

--- a/content/events/2020-07-22_continuous_integration_course.md
+++ b/content/events/2020-07-22_continuous_integration_course.md
@@ -1,7 +1,7 @@
 ---
 title: "Continuous Integration Course"
 date: 2020-07-22T14:00:00+01:00
-draft: false
+draft: true
 publishDate: 2020-06-17
 ---
 

--- a/content/events/2020-09-09_python_packaging_course.md
+++ b/content/events/2020-09-09_python_packaging_course.md
@@ -1,6 +1,6 @@
 ---
 title: "Python Packaging Course"
-date: 2020-08-12T14:00:00+01:00
+date: 2020-09-09T14:00:00+01:00
 draft: false
 publishDate: 2020-06-17
 ---
@@ -11,6 +11,6 @@ The Oxford Research Software Engineering group is running a free half day course
 
 **Where**: Online
 
-**When**: Wednesday 12th August
+**When**: Wednesday 9th September 2020
 
 More information coming soon!

--- a/content/events/2020-09-30_modern_cmake_course.md
+++ b/content/events/2020-09-30_modern_cmake_course.md
@@ -1,6 +1,6 @@
 ---
 title: "Modern CMake Course"
-date: 2020-09-02T14:00:00+01:00
+date: 2020-09-30T14:00:00+01:00
 draft: false
 publishDate: 2020-06-17
 ---
@@ -11,6 +11,6 @@ The Oxford Research Software Engineering group is running a free half day course
 
 **Where**: Online
 
-**When**: Wednesday 2nd September
+**When**: Wednesday 30th September 2020
 
 More information coming soon!

--- a/content/events/2020-10-21_modern_cpp_course.md
+++ b/content/events/2020-10-21_modern_cpp_course.md
@@ -37,7 +37,7 @@ Remote. We will use MS Teams or Zoom.
 
 ## When
 
-Wednesday 21th October 2020, from 14:00 to 17:00.
+Wednesday 21st October 2020, from 14:00 to 17:00.
 
 ## Contact
 

--- a/content/events/2020-10-21_modern_cpp_course.md
+++ b/content/events/2020-10-21_modern_cpp_course.md
@@ -1,13 +1,13 @@
 ---
 title: "Modern C++ Course"
-date: 2020-09-23T14:00:00+01:00
+date: 2020-10-21T14:00:00+01:00
 draft: false
 publishDate: 2020-03-03
 ---
 
 ![modern C++ course](/images/events/modern_cpp_course_1080.jpg "modern C++ course")
 
-23 September 2020 ~ Remote (MS Teams or Zoom) ~ More info coming soon!
+21 October 2020 ~ Remote (MS Teams or Zoom) ~ More info coming soon!
 
 The Oxford Research Software Engineering group is running a free half day course on modern C++ for for graduate students and researchers at the University of Oxford.
 
@@ -37,7 +37,7 @@ Remote. We will use MS Teams or Zoom.
 
 ## When
 
-Wednesday 23rd September 2020, from 14:00 to 17:00.
+Wednesday 21th October 2020, from 14:00 to 17:00.
 
 ## Contact
 


### PR DESCRIPTION
A couple of weeks back we decided not to organise any training for the month of August, so here's a suggestion for new dates.
Every 3 weeks as before, starting from wed 09th September:
- Python packaging : 09/09
- Mordern CMake: 30/09
- Modern C++: 21/10